### PR TITLE
Headers passed to the options would be silently ignored

### DIFF
--- a/lib/connect-static-file.js
+++ b/lib/connect-static-file.js
@@ -9,7 +9,7 @@ module.exports = function connectStaticFile(path, options)
         options = options || {};
         options = {
                 encoded: options.encoded,
-                headers: {}, // name => value
+                headers: options.headers, // name => value
 
                 // `send` options
                 etag: options.etag,


### PR DESCRIPTION
According to the documentation, headers to be sent along with the file, can be passed to the options object.
However, on initialization, the headers part of the options object was replaced by the empty object {}.
